### PR TITLE
Adds buildpack policies

### DIFF
--- a/policy/base.rego
+++ b/policy/base.rego
@@ -7,3 +7,7 @@ empty(value) {
 no_violations {
   empty(deny)
 }
+
+no_warnings {
+  empty(warn)
+}

--- a/policy/buildpacks.rego
+++ b/policy/buildpacks.rego
@@ -1,0 +1,77 @@
+package main
+
+warn[msg] {
+    input.applications[app].buildpack
+    msg := "The buildpack field has been deprecated. Buildpacks should be specified in the buildpacks array."  
+}
+
+deny[msg] {
+    input.applications[app].buildpack
+    input.applications[app].buildpacks
+    msg := "The buildpack field has been deprecated and cannot be used with the buildpacks array"
+}
+
+deny[msg] {
+    not count(input.applications[app].buildpacks) > 0
+    msg := "You must specify at least one buildpack in the buildpacks entry"
+}
+
+deny[msg] {
+    input.applications[app].buildpacks[pack] == ""
+    msg := "Entries in the buildpack array cannot be empty"
+}
+
+deny[msg] {
+    input.applications[app].buildpack == ""
+    msg := "You must specify a buildpack in the buildpack entry"
+}
+
+warn[msg] {
+    startswith(input.applications[app].buildpack, "http://")
+    msg := "Remote buildpacks may introduce untrusted code into your environment"
+}
+
+warn[msg] {
+    startswith(input.applications[app].buildpack, "https://")
+    msg := "Remote buildpacks may introduce untrusted code into your environment"
+}
+
+warn[msg] {
+    startswith(input.applications[app].buildpacks[pack], "http://")
+    msg := "Remote buildpacks may introduce untrusted code into your environment"
+}
+
+warn[msg] {
+    startswith(input.applications[app].buildpacks[pack], "https://")
+    msg := "Remote buildpacks may introduce untrusted code into your environment"
+}
+
+deny[msg] {
+    count(input.applications[app].buildpacks) > 1
+    input.applications[app].domain
+    msg := "Multiple buildpacks cannot be used with deprecated routing attributes"
+}
+
+deny[msg] {
+    count(input.applications[app].buildpacks) > 1
+    input.applications[app].domains
+    msg := "Multiple buildpacks cannot be used with deprecated routing attributes"
+}
+
+deny[msg] {
+    count(input.applications[app].buildpacks) > 1
+    input.applications[app].host
+    msg := "Multiple buildpacks cannot be used with deprecated routing attributes"
+}
+
+deny[msg] {
+    count(input.applications[app].buildpacks) > 1
+    input.applications[app].hosts
+    msg := "Multiple buildpacks cannot be used with deprecated routing attributes"
+}
+
+deny[msg] {
+    count(input.applications[app].buildpacks) > 1
+    input.applications[app]["no-hostname"]
+    msg := "Multiple buildpacks cannot be used with deprecated routing attributes"
+}

--- a/policy/buildpacks_test.rego
+++ b/policy/buildpacks_test.rego
@@ -1,0 +1,214 @@
+package main
+
+test_uses_buildpack_array {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "buildpacks": [
+                   "buildpack"
+                ]
+            }
+        ]
+    } 
+    no_violations with input as input
+    no_warnings with input as input
+}
+
+test_warn_deprecated_buildpack {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpack": "buildpack"
+            }
+        ]
+    }
+    warn["The buildpack field has been deprecated. Buildpacks should be specified in the buildpacks array."] with input as input
+}
+
+test_no_buildpack_with_buildpacks {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpack": "buildpack",
+                "buildpacks": [
+                   "buildpack"
+                ]
+            }
+        ]
+    }
+    deny["The buildpack field has been deprecated and cannot be used with the buildpacks array"] with input as input
+}
+
+test_no_empty_buildpack {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpacks": []
+            }
+        ]
+    }
+    deny["You must specify at least one buildpack in the buildpacks entry"] with input as input
+}
+
+test_no_empty_buildpack {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpacks": [""]
+            }
+        ]
+    }
+    deny["Entries in the buildpack array cannot be empty"] with input as input
+}
+
+test_no_empty_buildpack {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpack": ""
+            }
+        ]
+    }
+    deny["You must specify a buildpack in the buildpack entry"] with input as input
+}
+
+test_warn_remote_buildpack {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpack": "http://github.com/evil/bitcoin_miner.git"
+            }
+        ]
+    }
+    warn["Remote buildpacks may introduce untrusted code into your environment"] with input as input
+}
+
+test_warn_remote_buildpack {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpack": "https://github.com/evil/bitcoin_miner.git"
+            }
+        ]
+    }
+    warn["Remote buildpacks may introduce untrusted code into your environment"] with input as input
+}
+
+test_warn_remote_buildpack {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpacks": [
+                    "http://github.com/evil/bitcoin_miner.git"
+                ]
+            }
+        ]
+    }
+    warn["Remote buildpacks may introduce untrusted code into your environment"] with input as input
+}
+
+test_warn_remote_buildpack {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpack": "https://github.com/evil/bitcoin_miner.git"
+            }
+        ]
+    }
+    warn["Remote buildpacks may introduce untrusted code into your environment"] with input as input
+}
+
+test_no_multiple_with_deprecated_route_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpacks": [
+                    "buildpack",
+                    "another"
+                ],
+                "domain": "host.tld"
+            }
+        ]
+    }
+    deny["Multiple buildpacks cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_multiple_with_deprecated_route_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpacks": [
+                    "buildpack",
+                    "another"
+                ],
+                "domains": [
+                    "host.tld"
+                ]
+            }
+        ]
+    }
+    deny["Multiple buildpacks cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_multiple_with_deprecated_route_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpacks": [
+                    "buildpack",
+                    "another"
+                ],
+                "host": "app.host.tld"
+            }
+        ]
+    }
+    deny["Multiple buildpacks cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_multiple_with_deprecated_route_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpacks": [
+                    "buildpack",
+                    "another"
+                ],
+                "hosts": [
+                    "app.host.tld"
+                ]
+            }
+        ]
+    }
+    deny["Multiple buildpacks cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_multiple_with_deprecated_route_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "buildpacks": [
+                    "buildpack",
+                    "another"
+                ],
+                "no-hostname": true 
+            }
+        ]
+    }
+    deny["Multiple buildpacks cannot be used with deprecated routing attributes"] with input as input
+}
+


### PR DESCRIPTION
TL;DR
-----

Validates usage of the `buildpack` and `buildpacks` attributes

Details
-------

Adds policies for validating the buildpack(s) entries for all
applications in the manifest.

* Warns when the deprecated `buildpack` attribute is used instead
  of the supported `buildpacks` array.
* Assures that the `buildpacks` array and `buildpack` field are
  not used concurrently.
* Validates that provided buildpack entries are not empty.
* Warns on the risk of using remote buildpacks
* Assures that applications with multiple buildpacks do not use
  the deprecated routing attributes.
