### PR TITLE
Validates routing fields

### DIFF
--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -4,3 +4,8 @@ warn[msg] {
     input.applications[app].domain
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
+
+warn[msg] {
+    input.applications[app].domains
+    msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
+}

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -13,6 +13,23 @@ deny[msg] {
     msg := "Entries in the route array must have a route attribute"
 }
 
+valid_routes {
+    not has_empty_route
+}
+
+has_empty_route {
+    some app
+    some r
+    route := input.applications[app].routes[r]
+    route.route == ""
+}
+
+deny[msg] {
+    has_route_array
+    not valid_routes
+    msg := "Entries in the route array must specify a valid route"
+}
+
 warn[msg] {
     has_no_route
     has_route_array

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -14,3 +14,8 @@ warn[msg] {
     input.applications[app].host
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
+
+warn[msg] {
+    input.applications[app].hosts
+    msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
+}

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -1,6 +1,6 @@
 package main
 
-invalid_route_array_entry {
+has_invalid_route_structure {
     some app
     some r
     route := input.applications[app].routes[r]
@@ -9,15 +9,25 @@ invalid_route_array_entry {
 
 deny[msg] {
     has_route_array
-    invalid_route_array_entry
+    has_invalid_route_structure
     msg := "Entries in the route array must have a route attribute"
 }
 
-valid_routes {
-    not has_empty_route
+has_invalid_route_structure {
+    some app
+    some r
+    route := input.applications[app].routes[r]
+    not route.route
 }
 
-has_empty_route {
+
+deny[msg] {
+    has_route_array
+    has_empty_routes
+    msg := "Entries in the route array must specify a non-empty route"
+}
+
+has_empty_routes {
     some app
     some r
     route := input.applications[app].routes[r]

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -1,0 +1,6 @@
+package main
+
+warn[msg] {
+    input.applications[app].domain
+    msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
+}

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -9,3 +9,8 @@ warn[msg] {
     input.applications[app].domains
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
+
+warn[msg] {
+    input.applications[app].host
+    msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
+}

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -28,6 +28,16 @@ has_route_array {
 }
 
 warn[msg] {
+    has_random_route
+    has_route_array
+    msg := "Random route will not be generated if routes are specified"
+}
+
+has_random_route {
+    input.applications[app]["random-route"]
+}
+
+warn[msg] {
     has_domain
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
@@ -68,6 +78,12 @@ warn[msg] {
     msg := "Specifying no-route will override all other routing attributes"
 }
 
+warn[msg] {
+    has_random_route
+    has_host
+    msg := "Random route will not be generated if routes are specified"
+}
+
 has_host {
     input.applications[app].host
 }
@@ -81,6 +97,12 @@ warn[msg] {
     has_no_route
     has_hosts
     msg := "Specifying no-route will override all other routing attributes"
+}
+
+warn[msg] {
+    has_random_route
+    has_hosts
+    msg := "Random route will not be generated if routes are specified"
 }
 
 has_hosts {

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -36,8 +36,37 @@ has_empty_routes {
 
 deny[msg] {
     has_route_array
-    not valid_routes
-    msg := "Entries in the route array must specify a valid route"
+    has_name_without_domain
+    msg := "Entries in the route array must include a DNS domain"
+}
+
+has_name_without_domain {
+    some app
+    some r
+    route := input.applications[app].routes[r]
+    not contains(route.route, ".")
+}
+
+deny[msg] {
+    has_route_array
+    has_tcp_route
+    has_invalid_tcp_route
+    msg := "The port in a TCP route must be a number"
+}
+
+has_tcp_route {
+    some app
+    some r
+    route := input.applications[app].routes[r].route
+    count(split(route,":")) == 2
+}
+
+has_invalid_tcp_route {
+    some app
+    some r
+    route := input.applications[app].routes[r].route
+    contains(route,":")
+    not regex.match("[a-zA-Z.-]:\\d+", route) 
 }
 
 warn[msg] {

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -8,29 +8,83 @@ valid_route_array_structure {
 }
 
 deny[msg] {
-    input.applications[app].routes
+    has_route_array
     not valid_route_array_structure
     msg := "Entries in the route array must have a route attribute"
 }
 
 warn[msg] {
+    has_no_route
+    has_route_array
+    msg := "Specifying no-route will override all other routing attributes"
+}
+
+has_no_route {
+    input.applications[app]["no-route"]
+}
+
+has_route_array {
+    input.applications[app].routes
+}
+
+warn[msg] {
+    has_domain
+    msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
+}
+
+warn[msg] {
+    has_no_route
+    has_domain
+    msg := "Specifying no-route will override all other routing attributes"
+}
+
+has_domain {
     input.applications[app].domain
+}
+
+warn[msg] {
+    has_domains
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
 
 warn[msg] {
+    has_no_route
+    has_domains
+    msg := "Specifying no-route will override all other routing attributes"
+}
+
+has_domains {
     input.applications[app].domains
+}
+
+warn[msg] {
+    has_host
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
 
 warn[msg] {
+    has_no_route
+    has_host
+    msg := "Specifying no-route will override all other routing attributes"
+}
+
+has_host {
     input.applications[app].host
+}
+
+warn[msg] {
+    has_hosts
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
 
 warn[msg] {
+    has_no_route
+    has_hosts
+    msg := "Specifying no-route will override all other routing attributes"
+}
+
+has_hosts {
     input.applications[app].hosts
-    msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
 
 warn[msg] {
@@ -39,25 +93,25 @@ warn[msg] {
 }
 
 deny[msg] {
-    input.applications[app].routes
-    input.applications[app].domain
+    has_route_array
+    has_domain
     msg := "Routes array cannot be used with deprecated routing attributes"
 }
 
 deny[msg] {
-    input.applications[app].routes
-    input.applications[app].domains
+    has_route_array
+    has_domains
     msg := "Routes array cannot be used with deprecated routing attributes"
 }
 
 deny[msg] {
-    input.applications[app].routes
-    input.applications[app].host
+    has_route_array
+    has_host
     msg := "Routes array cannot be used with deprecated routing attributes"
 }
 
 deny[msg] {
-    input.applications[app].routes
-    input.applications[app].hosts
+    has_route_array
+    has_hosts
     msg := "Routes array cannot be used with deprecated routing attributes"
 }

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -1,15 +1,15 @@
 package main
 
-valid_route_array_structure {
+invalid_route_array_entry {
     some app
     some r
     route := input.applications[app].routes[r]
-    route.route
+    not route.route
 }
 
 deny[msg] {
     has_route_array
-    not valid_route_array_structure
+    invalid_route_array_entry
     msg := "Entries in the route array must have a route attribute"
 }
 

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -19,3 +19,8 @@ warn[msg] {
     input.applications[app].hosts
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
+
+warn[msg] {
+    input.applications[app]["no-hostname"]
+    msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
+}

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -24,3 +24,27 @@ warn[msg] {
     input.applications[app]["no-hostname"]
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
+
+deny[msg] {
+    input.applications[app].routes
+    input.applications[app].domain
+    msg := "Routes array cannot be used with deprecated routing attributes"
+}
+
+deny[msg] {
+    input.applications[app].routes
+    input.applications[app].domains
+    msg := "Routes array cannot be used with deprecated routing attributes"
+}
+
+deny[msg] {
+    input.applications[app].routes
+    input.applications[app].host
+    msg := "Routes array cannot be used with deprecated routing attributes"
+}
+
+deny[msg] {
+    input.applications[app].routes
+    input.applications[app].hosts
+    msg := "Routes array cannot be used with deprecated routing attributes"
+}

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -1,5 +1,18 @@
 package main
 
+valid_route_array_structure {
+    some app
+    some r
+    route := input.applications[app].routes[r]
+    route.route
+}
+
+deny[msg] {
+    input.applications[app].routes
+    not valid_route_array_structure
+    msg := "Entries in the route array must have a route attribute"
+}
+
 warn[msg] {
     input.applications[app].domain
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -56,3 +56,17 @@ test_warn_deprecated_host {
     warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
 }
 
+test_warn_deprecated_hosts {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "hosts": [
+                    "app.host.tld"
+                ],
+            }
+        ]
+    } 
+    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
+}
+

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -34,6 +34,18 @@ test_route_structure {
     deny["Entries in the route array must have a route attribute"] with input as input
 }
 
+test_no_empty_routes {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "routes": [ { "route": "" } ]
+            }
+        ]
+    }
+    deny["Entries in the route array must specify a valid route"] with input as input
+}
+
 test_warn_no_route_override {
     input := {
         "applications": [

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -1,0 +1,32 @@
+package main
+
+test_uses_routes_array {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "buildpacks": [
+                    "buildpack"
+                ],
+                "routes": [
+                   { "route": "app.host.tld" }
+                ]
+            }
+        ]
+    } 
+    no_violations with input as input
+    no_warnings with input as input
+}
+
+test_warn_deprecated_domain {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "domain": "host.tld"
+            }
+        ]
+    } 
+    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
+}
+

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -9,13 +9,29 @@ test_uses_routes_array {
                     "buildpack"
                 ],
                 "routes": [
-                   { "route": "app.host.tld" }
+                   { "route": "app.host.tld" },
+                   { "route": "app.host.tld:1234" },
+                   { "route": "app.host.tld/path"}
                 ]
             }
         ]
     } 
     no_violations with input as input
     no_warnings with input as input
+}
+
+test_route_structure {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "routes": [
+                    "app.host.tld"
+                ]
+            }
+        ]
+    }
+    deny["Entries in the route array must have a route attribute"] with input as input
 }
 
 test_warn_deprecated_domain {

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -44,3 +44,15 @@ test_warn_deprecated_domains {
     warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
 }
 
+test_warn_deprecated_host {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "host": "app.host.tld"
+            }
+        ]
+    } 
+    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
+}
+

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -30,3 +30,17 @@ test_warn_deprecated_domain {
     warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
 }
 
+test_warn_deprecated_domains {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "domains": [
+                    "host.tld"
+                ]
+            }
+        ]
+    } 
+    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
+}
+

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -102,6 +102,48 @@ test_warn_no_route_override {
     warn["Specifying no-route will override all other routing attributes"] with input as input 
 }
 
+test_warn_random_route_ignored {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "routes": { "route": "app.domain.tld" },
+                "random-route": true
+            }
+        ]
+    }
+    warn["Random route will not be generated if routes are specified"] with input as input
+}
+
+test_warn_random_route_ignored {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "host": "app",
+                "random-route": true
+            }
+        ]
+    }
+    warn["Random route will not be generated if routes are specified"] with input as input
+}
+
+test_warn_random_route_ignored {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "hosts": [
+                    "app",
+                    "another"
+                ],
+                "random-route": true
+            }
+        ]
+    }
+    warn["Random route will not be generated if routes are specified"] with input as input
+}
+
 test_warn_deprecated_domain {
     input := { 
         "applications": [

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -34,6 +34,74 @@ test_route_structure {
     deny["Entries in the route array must have a route attribute"] with input as input
 }
 
+test_warn_no_route_override {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "routes": { "route": "app.domain.tld" },
+                "no-route": true
+            }
+        ]
+    }    
+    warn["Specifying no-route will override all other routing attributes"] with input as input 
+}
+
+test_warn_no_route_override {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "domain": "domain.tld",
+                "no-route": true
+            }
+        ]
+    }    
+    warn["Specifying no-route will override all other routing attributes"] with input as input 
+}
+
+test_warn_no_route_override {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "domains": [ "domain.tld", "another.tld" ],
+                "no-route": true
+            }
+        ]
+    }    
+    warn["Specifying no-route will override all other routing attributes"] with input as input 
+}
+
+test_warn_no_route_override {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "host": "app",
+                "no-route": true
+            }
+        ]
+    }    
+    warn["Specifying no-route will override all other routing attributes"] with input as input 
+}
+
+test_warn_no_route_override {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "hosts": [
+                    "app",
+                    "another"
+                ],
+                "no-route": true
+            }
+        ]
+    }    
+    warn["Specifying no-route will override all other routing attributes"] with input as input 
+}
+
 test_warn_deprecated_domain {
     input := { 
         "applications": [
@@ -65,7 +133,7 @@ test_warn_deprecated_host {
         "applications": [
             {
                 "name": "application",
-                "host": "app.host.tld"
+                "host": "app"
             }
         ]
     } 
@@ -78,7 +146,8 @@ test_warn_deprecated_hosts {
             {
                 "name": "application",
                 "hosts": [
-                    "app.host.tld"
+                    "app",
+                    "another"
                 ],
             }
         ]

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -70,3 +70,14 @@ test_warn_deprecated_hosts {
     warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
 }
 
+test_warn_deprecated_hosts {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "no-hostname": true
+            }
+        ]
+    } 
+    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
+}

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -81,3 +81,67 @@ test_warn_deprecated_hosts {
     } 
     warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
 }
+
+test_no_routes_with_deprecated_component_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "routes": [
+                   { "route": "app.host.tld" }
+                ],
+                "domain": "host.tld"
+            }
+        ]
+    }
+    deny["Routes array cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_routes_with_deprecated_component_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "routes": [
+                   { "route": "app.host.tld" }
+                ],
+                "domains": [
+                    "host.tld"
+                ]
+            }
+        ]
+    }
+    deny["Routes array cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_routes_with_deprecated_component_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "routes": [
+                   { "route": "app.host.tld" }
+                ],
+                "host": "app.host.tld" 
+            }
+        ]
+    }
+    deny["Routes array cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_routes_with_deprecated_component_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "routes": [
+                   { "route": "app.host.tld" }
+                ],
+                "hosts": [
+                    "app.host.tld" 
+                ],
+            }
+        ]
+    }
+    deny["Routes array cannot be used with deprecated routing attributes"] with input as input
+}

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -43,7 +43,31 @@ test_no_empty_routes {
             }
         ]
     }
-    deny["Entries in the route array must specify a valid route"] with input as input
+    deny["Entries in the route array must specify a non-empty route"] with input as input
+}
+
+test_routes_are_qualified {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "routes": [ { "route": "host" } ]
+            }
+       ]
+    }
+    deny["Entries in the route array must include a DNS domain"] with input as input
+}
+
+test_tcp_ports_are_numbers {
+    input := {
+        "applications": [
+            {
+                "name": "application",
+                "routes": [ { "route": "host:http" } ]
+            }
+       ]
+    }
+    deny["The port in a TCP route must be a number"] with input as input
 }
 
 test_warn_no_route_override {


### PR DESCRIPTION
TL;DR
-----

Validates the routing fields are used consistently and warns against
using deprecated routing commponent attributes.

Details
-------

* Warns when the manifests uses one of the deprecated attributes to
  specify routing (`domain`, `domains`, `host`, `hosts`, and
  `no-hostname`)
* Disallows combining the new `routes` array with the deprecated 
  component fields, which will cause an error on push.
* Warns that `no-route` will override other routing fields
* Warns when `random-route` will be ignored
* Does a lightweight check on the entries in the `routes` array to
  make sure they are well formed, not empty, and that TCP routes 
  include a numeric port number.
* Repairs a defect where an ill-formed route array would pass 
  validation as long as at least one entry was well-formed.
