### PR TITLE
Automates releases with GitHub Actions

### DIFF
--- a/.github/actions/conftest-push/Dockerfile
+++ b/.github/actions/conftest-push/Dockerfile
@@ -1,3 +1,4 @@
 FROM instrumenta/conftest:latest
+FROM docker
 COPY /usr/local/bin/docker /docker
 

--- a/.github/actions/conftest-push/Dockerfile
+++ b/.github/actions/conftest-push/Dockerfile
@@ -1,3 +1,3 @@
-FROM instrumenta/conftest:latest
-FROM docker:latest
-
+FROM alpine 
+COPY --from=instrumenta/conftest /conftest /usr/local/bin/conftest
+COPY --from=docker /usr/local/bin/docker /usr/local/bin/docker

--- a/.github/actions/conftest-push/Dockerfile
+++ b/.github/actions/conftest-push/Dockerfile
@@ -1,0 +1,3 @@
+FROM instrumenta/conftest:latest
+COPY /usr/local/bin/docker /docker
+

--- a/.github/actions/conftest-push/Dockerfile
+++ b/.github/actions/conftest-push/Dockerfile
@@ -1,4 +1,3 @@
 FROM instrumenta/conftest:latest
-FROM docker
-COPY /usr/local/bin/docker /docker
+FROM docker:latest
 

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -21,5 +21,4 @@ runs:
   args:
   - -c
   - |
-    find /
-    # conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 
+    conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -5,8 +5,8 @@ branding:
   icon: "upload"
   color: "blue"
 inputs: 
-  path:
-    description: "Path to include in the bundle"
+  policy:
+    description: "Policies to include in the bundle"
     default: "policy" 
   repository:
     description: "Repository for the policy on an OCI-compliant registry supporting OPA bundles"
@@ -25,4 +25,4 @@ runs:
   - -c
   - |
     echo "${{ inputs.password }}" | docker login --username "${{ inputs.username }}" --password-stdin "${{ inputs.repository }}"
-    conftest push "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 
+    conftest push --policy ${{ inputs.policy }} "${{ inputs.repository }}:${{ inputs.tag }}"

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -7,10 +7,7 @@ branding:
 inputs: 
   path:
     description: "Path to include in the bundle"
-    default: "." 
-  policy:
-    description: "Where to find the policy folder or file"
-    default: "policy"
+    default: "policy" 
   repository:
     description: "Repository for the policy on an OCI-compliant registry supporting OPA bundles"
     required: true
@@ -28,4 +25,4 @@ runs:
   - -c
   - |
     docker login --username "${{ inputs.username }}" --password "${{ inputs.password }}" "${{ inputs.repository }}"
-    conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 
+    conftest push "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -27,5 +27,5 @@ runs:
   args:
   - -c
   - |
-    docker login --username "${{ inputs.username }}" --password "${{ inputs.password }}" 
+    docker login --username "${{ inputs.username }}" --password "${{ inputs.password }}" "${{ inputs.repository }}"
     conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -14,12 +14,18 @@ inputs:
   repository:
     description: "Repository for the policy on an OCI-compliant registry supporting OPA bundles"
     required: true
+  username:
+    description: 'Username used to log against the Docker registry'
+    required: false
+  password:
+    description: 'Password or personal access token used to log against the Docker registry'
+    required: true
 runs:
   using: 'docker'
-  image: 'docker://instrumenta/conftest:latest'
+  image: 'Dockerfile'
   entrypoint: sh
   args:
   - -c
   - |
-    docker
+    docker login --username "${{ inputs.username }}" --password "${{ inputs.password }}" 
     conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -21,4 +21,6 @@ runs:
   args:
   - -c
   - |
+    echo ${HOME}
+    find ${HOME}
     conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -21,4 +21,5 @@ runs:
   args:
   - -c
   - |
-    conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 
+    find /
+    # conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -21,4 +21,5 @@ runs:
   args:
   - -c
   - |
+    docker
     conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -21,6 +21,4 @@ runs:
   args:
   - -c
   - |
-    echo ${HOME}
-    find ${HOME}
     conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -1,0 +1,24 @@
+name: "Conftest Push"
+description: "Push an OPA bundle to an OCI-compliant registry"
+author: "Chuck D'Antonio"
+branding:
+  icon: "upload"
+  color: "blue"
+inputs: 
+  path:
+    description: "Path to include in the bundle"
+    default: "." 
+  policy:
+    description: "Where to find the policy folder or file"
+    default: "policy"
+  repository:
+    description: "Repository for the policy on an OCI-compliant registry supporting OPA bundles"
+    required: true
+runs:
+  using: 'docker'
+  image: 'docker://instrumenta/conftest:latest'
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    conftest push --policy "${{ inputs.policy }}" "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 

--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -24,5 +24,5 @@ runs:
   args:
   - -c
   - |
-    docker login --username "${{ inputs.username }}" --password "${{ inputs.password }}" "${{ inputs.repository }}"
+    echo "${{ inputs.password }}" | docker login --username "${{ inputs.username }}" --password-stdin "${{ inputs.repository }}"
     conftest push "${{ inputs.repository }}:${{ inputs.tag }}" "${{ inputs.path }}" 

--- a/.github/actions/conftest-verify/action.yml
+++ b/.github/actions/conftest-verify/action.yml
@@ -28,4 +28,5 @@ runs:
     fi
   
     echo ${HOME}
+    find ${HOME}
     # conftest verify ${TRACE} --output "${{ inputs.output }}" --policy "${{ inputs.policy }}" --data "${{ inputs.data }}"

--- a/.github/actions/conftest-verify/action.yml
+++ b/.github/actions/conftest-verify/action.yml
@@ -28,4 +28,4 @@ runs:
     fi
   
     echo ${HOME}
-    conftest verify ${TRACE} --output "${{ inputs.output }}" --policy "${{ inputs.policy }}" --data "${{ inputs.data }}"
+    # conftest verify ${TRACE} --output "${{ inputs.output }}" --policy "${{ inputs.policy }}" --data "${{ inputs.data }}"

--- a/.github/actions/conftest-verify/action.yml
+++ b/.github/actions/conftest-verify/action.yml
@@ -27,4 +27,6 @@ runs:
       TRACE="--trace"
     fi
   
+    pwd
+    ls
     conftest verify ${TRACE} --output "${{ inputs.output }}" --policy "${{ inputs.policy }}" --data "${{ inputs.data }}"

--- a/.github/actions/conftest-verify/action.yml
+++ b/.github/actions/conftest-verify/action.yml
@@ -27,6 +27,4 @@ runs:
       TRACE="--trace"
     fi
   
-    echo ${HOME}
-    find ${HOME}
-    # conftest verify ${TRACE} --output "${{ inputs.output }}" --policy "${{ inputs.policy }}" --data "${{ inputs.data }}"
+    conftest verify ${TRACE} --output "${{ inputs.output }}" --policy "${{ inputs.policy }}" --data "${{ inputs.data }}"

--- a/.github/actions/conftest-verify/action.yml
+++ b/.github/actions/conftest-verify/action.yml
@@ -23,8 +23,7 @@ runs:
   args:
   - -c
   - |
-    echo "Trace: " ${{ inputs.trace }}"
-    if [[ -n "${{ inputs.trace }} " ]]; then
+    if [[ -n "${{ inputs.trace }}" ]]; then
       TRACE="--trace"
     fi
   

--- a/.github/actions/conftest-verify/action.yml
+++ b/.github/actions/conftest-verify/action.yml
@@ -26,4 +26,4 @@ runs:
       TRACE="--trace"
     fi
   
-    conftest verify ${TRACE} --ouptut "${{ inputs.output }}" --policy "${{ inputs.policy }}" --data "${{ inputs.data }}"
+    conftest verify ${TRACE} --output "${{ inputs.output }}" --policy "${{ inputs.policy }}" --data "${{ inputs.data }}"

--- a/.github/actions/conftest-verify/action.yml
+++ b/.github/actions/conftest-verify/action.yml
@@ -15,6 +15,7 @@ inputs:
     default: "stdout"
   trace:
     description: "Enable more verbose tracing output"
+    default: 
 runs:
   using: 'docker'
   image: 'docker://instrumenta/conftest:latest'

--- a/.github/actions/conftest-verify/action.yml
+++ b/.github/actions/conftest-verify/action.yml
@@ -27,6 +27,5 @@ runs:
       TRACE="--trace"
     fi
   
-    pwd
-    ls
+    echo ${HOME}
     conftest verify ${TRACE} --output "${{ inputs.output }}" --policy "${{ inputs.policy }}" --data "${{ inputs.data }}"

--- a/.github/actions/conftest-verify/action.yml
+++ b/.github/actions/conftest-verify/action.yml
@@ -23,6 +23,7 @@ runs:
   args:
   - -c
   - |
+    echo "Trace: " ${{ inputs.trace }}"
     if [[ -n "${{ inputs.trace }} " ]]; then
       TRACE="--trace"
     fi

--- a/.github/actions/conftest-verify/action.yml
+++ b/.github/actions/conftest-verify/action.yml
@@ -1,0 +1,29 @@
+name: "Conftest Verify"
+description: "Run unit test to validate OPA policies for use with Conftest"
+author: "Chuck D'Antonio"
+branding:
+  icon: "check"
+  color: "green"
+inputs: 
+  policy:
+    description: "Where to find the policy folder or file"
+    default: "policy"
+  data:
+    description: "Paths from which data for the policies will be recursively loaded"
+  output:
+    description: "Output format for results"
+    default: "stdout"
+  trace:
+    description: "Enable more verbose tracing output"
+runs:
+  using: 'docker'
+  image: 'docker://instrumenta/conftest:latest'
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    if [[ -n "${{ inputs.trace }} " ]]; then
+      TRACE="--trace"
+    fi
+  
+    conftest verify ${TRACE} --ouptut "${{ inputs.output }}" --policy "${{ inputs.policy }}" --data "${{ inputs.data }}"

--- a/.github/actions/opa-bundle/action.yml
+++ b/.github/actions/opa-bundle/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: "package"
   color: "grey-dark"
 inputs: 
-  version:
+  revision:
     description: "Version of the bundle"
     require: true
   bundle:
@@ -19,8 +19,8 @@ runs:
   image: 'docker://openpolicyagent/opa:latest'
   args:
   - build
-  - --version
-  - "${{ inputs.version }}"
+  - --revision
+  - "${{ inputs.revision }}"
   - --bundle
   - "${{ inputs.bundle }}"
   - --output

--- a/.github/actions/opa-bundle/action.yml
+++ b/.github/actions/opa-bundle/action.yml
@@ -1,0 +1,27 @@
+name: "OPA Bundle"
+description: "Create a bundle of OPA policies"
+author: "Chuck D'Antonio"
+branding:
+  icon: "package"
+  color: "grey-dark"
+inputs: 
+  version:
+    description: "Version of the bundle"
+    require: true
+  bundle:
+    description: "Paths to policy files for the bundle"
+    default: "policy"
+  output:
+    description: "Output filename for the bundle tarball"
+    default: "bundle.tar.gz"
+runs:
+  using: 'docker'
+  image: 'docker://openpolicyagent/opa:latest'
+  args:
+  - build
+  - --version
+  - "${{ inputs.version }}"
+  - --bundle
+  - "${{ inputs.bundle }}"
+  - --output
+  - "/github/workspace/${{ inputs.output }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           repository: ghcr.io/crdant/cf-manifest-policy
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
+      - name: Expose Docker Config
+        run: |
+          cp -r ${HOME}/.docker /home/runner/work/_temp/_github_home/
       - name: Checkout
         uses: actions/checkout@v2
       - name: Push to registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ jobs:
     name: Release the OPA bundle
     runs-on: ubuntu-latest
     needs: test
-    container:
-      volumes:
-      - /home/runner:/github/home
     steps:
       - name: Docker Login
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Docker Login
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Push to registry
         uses: ./.github/actions/conftest-push
         with:
-          repository: crdant.azurecr.io/cf-manifest-policy
+          repository: ghcr.io/crdant/cf-manifest-policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,67 @@
 name: Release
 
-on: push
+on: [ push ] 
 
 jobs:
   test:
-    name: Unit test the policies
+    name: Unit test policies
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 
+        id: checkout
         uses: actions/checkout@v2
-      - name: Verify policies
+      - name: Verify Policies
+        id: verify
         uses: ./.github/actions/conftest-verify
+     
+  release: 
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: push
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v2
+      - name: Create OPA Bundle
+        id: create_bundle
+        uses: docker
+        image: docker://openpolicyagent/opa:latest
+        run:
+          build --version ${GITHUB_REF} --bundle policy --output /github/workspace/policy.tar.gz 
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: true
+      - name: Add Bundle as Release Asset
+        id: add_bundle
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: policy.tar.gz
+          asset_name: cf-manifest-policy.tar.gz
+          asset_content_type: application/x-gtar
           
-  release:
-    name: Release the OPA bundle
+  push:
+    name: Push OPA bundle to the regisry
     runs-on: ubuntu-latest
     needs: test
     steps:
       - name: Checkout
+        id: checkout
         uses: actions/checkout@v2
-      - name: Push to registry
+      - name: Push to Registry
+        id: push
         uses: ./.github/actions/conftest-push
         with:
           repository: ghcr.io/crdant/cf-manifest-policy
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
     name: Release the OPA bundle
     runs-on: ubuntu-latest
     needs: test
+    container:
+      volumes:
+      - /home/runner:/github/home
     steps:
       - name: Docker Login
         uses: docker/login-action@v1
@@ -27,8 +30,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Push to registry
         uses: ./.github/actions/conftest-push
-        container:
-          volumes:
-          - /home/runner:/github/home
         with:
           repository: ghcr.io/crdant/cf-manifest-policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
   release:
     name: Release the OPA bundle
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - name: Checkout 
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Docker Login
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Push to registry
         uses: ./.github/actions/conftest-push
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   release: 
     name: Create GitHub release
     runs-on: ubuntu-latest
-    needs: push
+    needs: test
     steps:
       - name: Checkout
         id: checkout
@@ -52,7 +52,7 @@ jobs:
   push:
     name: Push OPA bundle to the regisry
     runs-on: ubuntu-latest
-    needs: test
+    needs: release
     steps:
       - name: Checkout
         id: checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Debug
+        run: "echo ${HOME}"
       - name: Push to registry
         uses: ./.github/actions/conftest-push
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Push to registry
-        run: |
-          cp -r ${HOME}/.docker /home/runner/work/_temp/_github_home/
         uses: ./.github/actions/conftest-push
         with:
           repository: ghcr.io/crdant/cf-manifest-policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Create OPA Bundle
         id: create_bundle
-        uses: ./.github/actions/conftest-push
+        uses: ./.github/actions/opa-bundle
         with:
           version: ${{ github.ref }}
           output: policy.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@v1
         with:
+          registry: crdant.azurecr.io
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_SECRET }}
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - name: Docker Login
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v2
       - name: Push to registry
         uses: ./.github/actions/conftest-push
         with:
           repository: ghcr.io/crdant/cf-manifest-policy
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Release
 
-on: [ push ] 
+on: 
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+    
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on: push
+
+jobs:
+  test:
+    name: Unit test the policies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v2
+      - name: Verify policies
+        uses: ./.github/actions/conftest-verify
+          
+  release:
+    name: Release the OPA bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v2
+      - name: Push to registry
+        uses: ./.github/actions/conftest-push
+        with:
+          repository: crdant.azurecr.io/cf-manifest-policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@v1
         with:
-          registry: crdant.azurecr.io
-          username: ${{ secrets.ACR_USERNAME }}
-          password: ${{ secrets.ACR_SECRET }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v2
       - name: Push to registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         id: create_bundle
         uses: ./.github/actions/opa-bundle
         with:
-          version: ${{ github.ref }}
+          revision: ${{ github.ref }}
           output: policy.tar.gz
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,10 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Debug
-        run: |
-          echo ${HOME}
-          find ${HOME}
       - name: Push to registry
         uses: ./.github/actions/conftest-push
+        container:
+          volumes:
+          - /home/runner:/github/home
         with:
           repository: ghcr.io/crdant/cf-manifest-policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - name: Checkout 
+      - name: Docker Login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_SECRET }}
+      - name: Checkout
         uses: actions/checkout@v2
       - name: Push to registry
         uses: ./.github/actions/conftest-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Debug
-        run: "echo ${HOME}"
+        run: |
+          echo ${HOME}
+          find ${HOME}
       - name: Push to registry
         uses: ./.github/actions/conftest-push
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Create OPA Bundle
         id: create_bundle
-        uses: docker
-        image: docker://openpolicyagent/opa:latest
-        run:
-          build --version ${GITHUB_REF} --bundle policy --output /github/workspace/policy.tar.gz 
+        uses: ./.github/actions/conftest-push
+        with:
+          version: ${{ github.ref }}
+          output: policy.tar.gz
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
-      - name: Expose Docker Config
-        run: |
-          cp -r ${HOME}/.docker /home/runner/work/_temp/_github_home/
       - name: Checkout
         uses: actions/checkout@v2
       - name: Push to registry
+        run: |
+          cp -r ${HOME}/.docker /home/runner/work/_temp/_github_home/
         uses: ./.github/actions/conftest-push
         with:
           repository: ghcr.io/crdant/cf-manifest-policy


### PR DESCRIPTION
TL;DR
------

Adds CD capabilities that produce a GitHub release and push the bundle to GitHub Container Registry

Details
-------

Continuously delivers the polices to a GitHub release and an OPA Bundle in the GitHub Container Registry whenever a new tag marking a release is applied to `main`.

The workflow:

* Runs the policy tests with `conftest verify`
* Uses a custom action that creates an OPA bundle with the `opa` CLI and releases that bundle on GitHub
* Pushes the release to the GitHub Container Registry so `conftest` uses can invoke it directly from there

At this time there are two distinct bundles: one that is available as a GitHub release (created with `opa` build) and one that
is created by Conftest when pushed to the registry with `conftest push`. This was necessary because current tooling makes it difficult to push a pre-created bundle to an OCI registry. I suspect that situation to remedy itself.
