### PR TITLE
Adds policies that check resiliency fields

### DIFF
--- a/policy/applications.rego
+++ b/policy/applications.rego
@@ -35,7 +35,24 @@ has_health_check_type {
 
 has_valid_health_check {
     health_check_types := [ "process", "port", "http" ]
+    
     some app
     some type
     health_check_types[type] == input.applications[app]["health-check-type"]
-}    
+}
+
+warn[msg] {
+    some app
+    input.applications[app]["no-route"]
+    not input.applications[app]["health-check-type"]
+    
+    msg = sprintf("If application %v does not listen on a port, Diego will mark it as crashed.", [ input.applications[app].name ])
+}
+
+warn[msg] {
+    some app
+    input.applications[app]["no-route"]
+    not input.applications[app]["health-check-type"] == "process"
+    
+    msg = sprintf("If application %v does not listen on a port, Diego will mark it as crashed.", [ input.applications[app].name ])
+}

--- a/policy/applications.rego
+++ b/policy/applications.rego
@@ -10,3 +10,10 @@ warn[msg] {
     input.applications[app].instances == 1
     msg = "To ensure that platform maintenance does not interrupt your app, run at least two instances."
 }
+
+deny[msg] {
+    some app
+    input.applications[app].instances == 0
+    trace(sprintf("There will be no running instances of application %v", [ input.applications[app].name ]))
+    msg = sprintf("There will be no running instances of application %v", [ input.applications[app].name ])
+}

--- a/policy/applications.rego
+++ b/policy/applications.rego
@@ -14,6 +14,11 @@ warn[msg] {
 deny[msg] {
     some app
     input.applications[app].instances == 0
-    trace(sprintf("There will be no running instances of application %v", [ input.applications[app].name ]))
     msg = sprintf("There will be no running instances of application %v", [ input.applications[app].name ])
+}
+
+deny[msg] {
+    some app
+    input.applications[app]["health-check-type"] == "none"
+    msg = "Health check type none has been removed in the latest Cloud Foundry CLI"
 }

--- a/policy/applications.rego
+++ b/policy/applications.rego
@@ -4,3 +4,9 @@ deny[msg] {
     not input.applications
     msg = "Manifest must include at least one application to deploy"
 }
+
+warn[msg] {
+    some app
+    input.applications[app].instances == 1
+    msg = "To ensure that platform maintenance does not interrupt your app, run at least two instances."
+}

--- a/policy/applications.rego
+++ b/policy/applications.rego
@@ -22,3 +22,20 @@ deny[msg] {
     input.applications[app]["health-check-type"] == "none"
     msg = "Health check type none has been removed in the latest Cloud Foundry CLI"
 }
+
+deny[msg] {
+    has_health_check_type
+    not has_valid_health_check
+    msg = "Health check type must be port, process, or http"
+}
+
+has_health_check_type {
+    input.applications[app]["health-check-type"]
+}    
+
+has_valid_health_check {
+    health_check_types := [ "process", "port", "http" ]
+    some app
+    some type
+    health_check_types[type] == input.applications[app]["health-check-type"]
+}    

--- a/policy/applications_test.rego
+++ b/policy/applications_test.rego
@@ -62,3 +62,41 @@ test_health_check_type {
   }
   deny["Health check type must be port, process, or http"] with input as input
 }
+
+test_no_route_health_check {
+  input := {
+    "applications": [
+      { 
+        "name": "foo",
+        "no-route": true
+      }
+    ]
+  }
+  warn["If application foo does not listen on a port, Diego will mark it as crashed."] with input as input
+}
+
+test_no_route_health_check {
+  input := {
+    "applications": [
+      { 
+        "name": "foo",
+        "no-route": true,
+        "health-check-type": "process"
+      }
+    ]
+  }
+  not warn["If application foo does not listen on a port, Diego will mark it as crashed."] with input as input
+}
+
+test_no_route_health_check {
+  input := {
+    "applications": [
+      { 
+        "name": "foo",
+        "no-route": true,
+        "health-check-type": "port"
+      }
+    ]
+  }
+  warn["If application foo does not listen on a port, Diego will mark it as crashed."] with input as input
+}

--- a/policy/applications_test.rego
+++ b/policy/applications_test.rego
@@ -38,3 +38,15 @@ test_no_zero_instance_applications {
   }
   deny["There will be no running instances of application foo"] with input as input
 }
+
+test_warn_health_check_none {
+  input := {
+    "applications": [
+      { 
+        "name": "foo",
+        "health-check-type": "none"
+      }
+    ]
+  }
+  deny["Health check type none has been removed in the latest Cloud Foundry CLI"] with input as input
+}

--- a/policy/applications_test.rego
+++ b/policy/applications_test.rego
@@ -15,7 +15,7 @@ test_manifest_with_no_applications {
   deny["Manifest must include at least one application to deploy"] with input as {}
 }
 
-test_warn_with_only_one_interface {
+test_warn_with_only_one_instance {
   input := {
     "applications": [
       { 
@@ -25,4 +25,16 @@ test_warn_with_only_one_interface {
     ]
   }
   warn["To ensure that platform maintenance does not interrupt your app, run at least two instances."] with input as input
+}
+
+test_no_zero_instance_applications {
+  input := {
+    "applications": [
+      { 
+        "name": "foo",
+        "instances": 0
+      }
+    ]
+  }
+  deny["There will be no running instances of application foo"] with input as input
 }

--- a/policy/applications_test.rego
+++ b/policy/applications_test.rego
@@ -14,3 +14,15 @@ test_minimal_manifest{
 test_manifest_with_no_applications {
   deny["Manifest must include at least one application to deploy"] with input as {}
 }
+
+test_warn_with_only_one_interface {
+  input := {
+    "applications": [
+      { 
+        "name": "application",
+        "instances": 1
+      }
+    ]
+  }
+  warn["To ensure that platform maintenance does not interrupt your app, run at least two instances."] with input as input
+}

--- a/policy/applications_test.rego
+++ b/policy/applications_test.rego
@@ -39,7 +39,7 @@ test_no_zero_instance_applications {
   deny["There will be no running instances of application foo"] with input as input
 }
 
-test_warn_health_check_none {
+test_no_health_check_none {
   input := {
     "applications": [
       { 
@@ -49,4 +49,16 @@ test_warn_health_check_none {
     ]
   }
   deny["Health check type none has been removed in the latest Cloud Foundry CLI"] with input as input
+}
+
+test_health_check_type {
+  input := {
+    "applications": [
+      { 
+        "name": "foo",
+        "health-check-type": "ssh"
+      }
+    ]
+  }
+  deny["Health check type must be port, process, or http"] with input as input
 }


### PR DESCRIPTION
TL;DR
-----

Checks resiliency features of the manifest

Details
-------

* Warns when running only one instance of an application. I
  considered making this a failure but it's likely people 
  will do this in early staged of development and don't want
  to prevent that.
* Makes sure that the manifest doesn't request that zero 
  instances will run. There are probably scenarios in which
  to allow this, but much more likely a mistake.
* Rejects the removed (CLIv7)/deprecated (CLIv6) `none` type
  for health checks. Since the supported versions of the CLI
  support an alternative it felt right to not allow it.
* Warns if an application without a route doesn't have the 
  `process` health check type. I'm still not sure I shouldn't
  reject these, but can come up with a few scenarios where
  I'd want to do it so it's just a warning.
* Validates that the `health-check-type` is an allowed value.
