### PR TITLE
feature/docker applications

### DIFF
--- a/policy/docker.rego
+++ b/policy/docker.rego
@@ -1,0 +1,30 @@
+package main
+
+deny[msg] {
+    some app
+    input.applications[app].docker
+    input.applications[app].buildpack
+    msg = "You cannot specify buildpack(s) when pushing a docker image"
+}
+
+deny[msg] {
+    some app
+    input.applications[app].docker
+    input.applications[app].buildpacks
+    msg = "You cannot specify buildpack(s) when pushing a docker image"
+}
+
+deny[msg] {
+    some app
+    input.applications[app].docker.username
+    not input.applications[app].env["CF_DOCKER_PASSWORD"]
+    msg = "If you provide a username for the docker image, the password must be provided in the environment variable CF_DOCKER_PASSWORD"
+}
+
+warn[msg] {
+    some app
+    input.applications[app].env["CF_DOCKER_PASSWORD"]
+    not input.applications[app].docker.username
+    
+    msg = "You set CF_DOCKER_PASSWORD for application foo but not a docker username"
+}

--- a/policy/docker_test.rego
+++ b/policy/docker_test.rego
@@ -1,0 +1,97 @@
+package main
+
+test_uses_docker_image {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "docker": {
+                    "image": "cloudfoundry/test-app"
+                }
+            }
+        ]
+    } 
+    no_violations with input as input
+    no_warnings with input as input
+}
+
+test_no_docker_and_buildpacks {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "docker": {
+                    "image": "cloudfoundry/test-app"
+                },
+                "buildpack": "buildpack"
+            }
+        ]
+    }
+    deny["You cannot specify buildpack(s) when pushing a docker image"] with input as input
+}
+
+test_no_docker_and_buildpacks {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "docker": {
+                    "image": "cloudfoundry/test-app"
+                },
+                "buildpacks": [ "buildpack" ]
+            }
+        ]
+    }
+    deny["You cannot specify buildpack(s) when pushing a docker image"] with input as input
+}
+
+test_uses_private_docker_image {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "docker": {
+                    "image": "cloudfoundry/test-app",
+                    "username": "crdant"
+                },
+                "env": {
+                    "CF_DOCKER_PASSWORD": "hunter2"
+                }
+            }
+        ]
+    } 
+    no_violations with input as input
+    no_warnings with input as input
+}
+
+test_docker_auth_is_complete {
+    input := { 
+        "applications": [
+            {
+                "name": "application",
+                "docker": {
+                    "image": "cloudfoundry/test-app",
+                    "username": "crdant"
+                },
+            }
+        ]
+    }
+    deny["If you provide a username for the docker image, the password must be provided in the environment variable CF_DOCKER_PASSWORD"] with input as input
+}
+
+test_docker_auth_is_complete {
+    input := { 
+        "applications": [
+            {
+                "name": "foo",
+                "docker": {
+                    "image": "cloudfoundry/test-app",
+                },
+                "env": {
+                    "CF_DOCKER_PASSWORD": "hunter2"
+                }
+            }
+        ]
+    }
+    warn["You set CF_DOCKER_PASSWORD for application foo but not a docker username"] with input as input
+}


### PR DESCRIPTION
TL;DR
-----

Validats manifets for deploying docker images as applications

Details
-------

Incorporates some checks for when a Docker image is deployed as
a Cloud Foundry application. I'm reserving judgement on whether
or not this is a good idea (thus no warning when you do it).

* Assures that a docker image and a buildpack aren't specified
   for the same application.
* Validates that the username and password are both provided
   when authentication is required. Currently only warns when a
   password is provided without a username.