### PR TITLE
Accomodates multiple applications per manifest

### DIFF
--- a/policy/applications.rego
+++ b/policy/applications.rego
@@ -5,6 +5,14 @@ deny[msg] {
     msg = "Manifest must include at least one application to deploy"
 }
 
+deny[msg] {
+    some app
+    some other
+    input.applications[app].name == input.applications[other].name
+    not app == other
+    msg = "Applications must have unique names"
+}
+
 warn[msg] {
     some app
     input.applications[app].instances == 1

--- a/policy/applications.rego
+++ b/policy/applications.rego
@@ -7,9 +7,10 @@ deny[msg] {
 
 deny[msg] {
     some app
-    some other
-    input.applications[app].name == input.applications[other].name
-    not app == other
+    some another
+    input.applications[app].name == input.applications[another].name
+    not app == another
+
     msg = "Applications must have unique names"
 }
 

--- a/policy/applications_test.rego
+++ b/policy/applications_test.rego
@@ -11,6 +11,118 @@ test_minimal_manifest{
   no_violations with input as input
 }
 
+test_multiple_apps {
+  input := {
+    "applications": [
+      { 
+        "name": "foo"
+      },
+      {
+        "name": "bar"
+      }
+    ]
+  }
+  no_violations with input as input
+}
+
+test_unique_application_names {
+  input := {
+    "applications": [
+      { 
+        "name": "foo"
+      },
+      {
+        "name": "foo"
+      }
+    ]
+  }
+  deny["Applications must have unique names"] with input as input
+}
+
+test_multiple_apps {
+  input := {
+    "applications": [
+      { 
+        "name": "foo"
+      },
+      {
+        "name": "bar"
+      }
+    ]
+  }
+  no_violations with input as input
+}
+
+test_multiple_apps {
+  input := {
+    "applications": [
+      { 
+        "name": "foo"
+      },
+      {
+        "name": "bar"
+      }
+    ]
+  }
+  no_violations with input as input
+}
+
+test_multiple_apps {
+  input := {
+    "applications": [
+      { 
+        "name": "foo"
+      },
+      {
+        "name": "bar"
+      }
+    ]
+  }
+  no_violations with input as input
+}
+
+test_multiple_apps {
+  input := {
+    "applications": [
+      { 
+        "name": "foo"
+      },
+      {
+        "name": "bar"
+      }
+    ]
+  }
+  no_violations with input as input
+}
+
+test_multiple_apps {
+  input := {
+    "applications": [
+      { 
+        "name": "foo"
+      },
+      {
+        "name": "bar"
+      }
+    ]
+  }
+  no_violations with input as input
+}
+
+test_multiple_apps {
+  input := {
+    "applications": [
+      { 
+        "name": "foo"
+      },
+      {
+        "name": "bar"
+      }
+    ]
+  }
+  no_violations with input as input
+}
+
 test_manifest_with_no_applications {
   deny["Manifest must include at least one application to deploy"] with input as {}
 }

--- a/policy/buildpacks_test.rego
+++ b/policy/buildpacks_test.rego
@@ -42,6 +42,24 @@ test_no_buildpack_with_buildpacks {
     deny["The buildpack field has been deprecated and cannot be used with the buildpacks array"] with input as input
 }
 
+test_no_buildpack_with_buildpacks {
+    input := {
+        "applications": [
+            {
+                "name": "foo",
+                "buildpack": "buildpack"
+            },
+            {
+                "name": "bar",
+                "buildpacks": [
+                   "buildpack"
+                ]
+            }
+        ]
+    }
+    no_violations with input as input
+}
+
 test_no_empty_buildpack {
     input := {
         "applications": [
@@ -148,6 +166,25 @@ test_no_multiple_with_deprecated_route_attributes {
     input := {
         "applications": [
             {
+                "name": "foo",
+                "buildpacks": [
+                    "buildpack",
+                    "another"
+                ]
+            },
+            {   
+                "name": "bar",
+                "domain": "host.tld"
+            }
+        ]
+    }
+    no_violations with input as input
+}
+
+test_no_multiple_with_deprecated_route_attributes {
+    input := {
+        "applications": [
+            {
                 "name": "application",
                 "buildpacks": [
                     "buildpack",
@@ -171,11 +208,30 @@ test_no_multiple_with_deprecated_route_attributes {
                     "buildpack",
                     "another"
                 ],
-                "host": "app.host.tld"
+                "host": "app"
             }
         ]
     }
     deny["Multiple buildpacks cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_multiple_with_deprecated_route_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "foo",
+                "buildpacks": [
+                    "buildpack",
+                    "another"
+                ]
+            },
+            {
+                "name": "bar",
+                "host": "app"
+            }
+        ]
+    }
+    no_violations with input as input
 }
 
 test_no_multiple_with_deprecated_route_attributes {
@@ -188,12 +244,33 @@ test_no_multiple_with_deprecated_route_attributes {
                     "another"
                 ],
                 "hosts": [
-                    "app.host.tld"
+                    "app"
                 ]
             }
         ]
     }
     deny["Multiple buildpacks cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_multiple_with_deprecated_route_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "foo",
+                "buildpacks": [
+                    "buildpack",
+                    "another"
+                ]
+            },
+            {
+                "name": "bar",
+                "hosts": [
+                    "app"
+                ]
+            }
+        ]
+    }
+    no_violations with input as input
 }
 
 test_no_multiple_with_deprecated_route_attributes {
@@ -210,5 +287,24 @@ test_no_multiple_with_deprecated_route_attributes {
         ]
     }
     deny["Multiple buildpacks cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_multiple_with_deprecated_route_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "foo",
+                "buildpacks": [
+                    "buildpack",
+                    "another"
+                ]
+            },
+            {
+                "name": "bar",
+                "no-hostname": true 
+            }
+        ]
+    }
+    no_violations with input as input
 }
 

--- a/policy/routes.rego
+++ b/policy/routes.rego
@@ -1,6 +1,6 @@
 package main
 
-has_invalid_route_structure {
+has_invalid_route_structure[app] {
     some app
     some r
     route := input.applications[app].routes[r]
@@ -8,26 +8,20 @@ has_invalid_route_structure {
 }
 
 deny[msg] {
-    has_route_array
-    has_invalid_route_structure
+    some app
+    has_route_array[app]
+    has_invalid_route_structure[app]
     msg := "Entries in the route array must have a route attribute"
 }
 
-has_invalid_route_structure {
-    some app
-    some r
-    route := input.applications[app].routes[r]
-    not route.route
-}
-
-
 deny[msg] {
-    has_route_array
-    has_empty_routes
+    some app
+    has_route_array[app]
+    has_empty_routes[app]
     msg := "Entries in the route array must specify a non-empty route"
 }
 
-has_empty_routes {
+has_empty_routes[app]{
     some app
     some r
     route := input.applications[app].routes[r]
@@ -35,12 +29,13 @@ has_empty_routes {
 }
 
 deny[msg] {
-    has_route_array
-    has_name_without_domain
+    some app
+    has_route_array[app]
+    has_name_without_domain[app]
     msg := "Entries in the route array must include a DNS domain"
 }
 
-has_name_without_domain {
+has_name_without_domain[app] {
     some app
     some r
     route := input.applications[app].routes[r]
@@ -48,20 +43,21 @@ has_name_without_domain {
 }
 
 deny[msg] {
-    has_route_array
-    has_tcp_route
-    has_invalid_tcp_route
+    some app
+    has_route_array[app]
+    has_tcp_route[app] 
+    has_invalid_tcp_route[app] 
     msg := "The port in a TCP route must be a number"
 }
 
-has_tcp_route {
+has_tcp_route[app] {
     some app
     some r
     route := input.applications[app].routes[r].route
     count(split(route,":")) == 2
 }
 
-has_invalid_tcp_route {
+has_invalid_tcp_route[app] {
     some app
     some r
     route := input.applications[app].routes[r].route
@@ -70,98 +66,106 @@ has_invalid_tcp_route {
 }
 
 warn[msg] {
-    has_no_route
-    has_route_array
+    some app
+    has_no_route[app] 
+    has_route_array[app]
     msg := "Specifying no-route will override all other routing attributes"
 }
 
-has_no_route {
+has_no_route[app] {
     input.applications[app]["no-route"]
 }
 
-has_route_array {
+has_route_array[app] {
     input.applications[app].routes
 }
 
 warn[msg] {
-    has_random_route
-    has_route_array
+    some app
+    has_random_route[app]
+    has_route_array[app]
     msg := "Random route will not be generated if routes are specified"
 }
 
-has_random_route {
+has_random_route[app] {
     input.applications[app]["random-route"]
 }
 
 warn[msg] {
-    has_domain
+    has_domain[app]
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
 
 warn[msg] {
-    has_no_route
-    has_domain
+    some app
+    has_no_route[app]
+    has_domain[app]
     msg := "Specifying no-route will override all other routing attributes"
 }
 
-has_domain {
+has_domain[app] {
     input.applications[app].domain
 }
 
 warn[msg] {
-    has_domains
+    has_domains[app]
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
 
 warn[msg] {
-    has_no_route
-    has_domains
+    some app
+    has_no_route[app]
+    has_domains[app]
     msg := "Specifying no-route will override all other routing attributes"
 }
 
-has_domains {
+has_domains[app] {
     input.applications[app].domains
 }
 
 warn[msg] {
-    has_host
+    has_host[app]
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
 
 warn[msg] {
-    has_no_route
-    has_host
+    some app
+    has_no_route[app]
+    has_host[app]
     msg := "Specifying no-route will override all other routing attributes"
 }
 
 warn[msg] {
-    has_random_route
-    has_host
+    some app
+    has_random_route[app]
+    has_host[app]
     msg := "Random route will not be generated if routes are specified"
 }
 
-has_host {
+has_host[app] {
     input.applications[app].host
 }
 
 warn[msg] {
-    has_hosts
+    has_hosts[app]
     msg := "The component attributes for specifying routes have been deprecated. Use the routes array instead."
 }
 
 warn[msg] {
-    has_no_route
-    has_hosts
+    some app
+    has_no_route[app]
+    has_hosts[app]
     msg := "Specifying no-route will override all other routing attributes"
 }
 
 warn[msg] {
-    has_random_route
-    has_hosts
+    some app
+    has_random_route[app]
+    has_hosts[app]
     msg := "Random route will not be generated if routes are specified"
 }
 
-has_hosts {
+has_hosts[app] {
     input.applications[app].hosts
 }
 
@@ -171,25 +175,29 @@ warn[msg] {
 }
 
 deny[msg] {
-    has_route_array
-    has_domain
+    some app
+    has_route_array[app]
+    has_domain[app]
     msg := "Routes array cannot be used with deprecated routing attributes"
 }
 
 deny[msg] {
-    has_route_array
-    has_domains
+    some app
+    has_route_array[app]
+    has_domains[app]
     msg := "Routes array cannot be used with deprecated routing attributes"
 }
 
 deny[msg] {
-    has_route_array
-    has_host
+    some app
+    has_route_array[app]
+    has_host[app]
     msg := "Routes array cannot be used with deprecated routing attributes"
 }
 
 deny[msg] {
-    has_route_array
-    has_hosts
+    some app
+    has_route_array[app]
+    has_hosts[app]
     msg := "Routes array cannot be used with deprecated routing attributes"
 }

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -17,28 +17,6 @@ test_uses_routes_array {
     no_warnings with input as input
 }
 
-test_multiple_apps_routes_and_host {
-    input := { 
-        "applications": [
-            {
-                "name": "foo",
-                "routes": [
-                   { "route": "app.host.tld" },
-                   { "route": "app.host.tld:1234" },
-                   { "route": "app.host.tld/path"}
-                ]
-            },
-            {
-                "name": "bar",
-                "host": "app"
-            }
-        ]
-    } 
-    
-    no_violations with input as input
-    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
-}
-
 test_route_structure {
     input := {
         "applications": [
@@ -106,6 +84,22 @@ test_warn_no_route_override {
     input := {
         "applications": [
             {
+                "name": "foo",
+                "routes": { "route": "app.domain.tld" },
+            },
+            {
+                "name": "bar",
+                "no-route": true
+            }
+        ]
+    }    
+    not warn["Specifying no-route will override all other routing attributes"] with input as input 
+}
+
+test_warn_no_route_override {
+    input := {
+        "applications": [
+            {
                 "name": "application",
                 "domain": "domain.tld",
                 "no-route": true
@@ -113,6 +107,22 @@ test_warn_no_route_override {
         ]
     }    
     warn["Specifying no-route will override all other routing attributes"] with input as input 
+}
+
+test_warn_no_route_override {
+    input := {
+        "applications": [
+            {
+                "name": "foo",
+                "domain": "domain.tld",
+            },
+            {
+                "name": "bar",
+                "no-route": true
+            }
+        ]
+    }    
+    not warn["Specifying no-route will override all other routing attributes"] with input as input 
 }
 
 test_warn_no_route_override {
@@ -132,6 +142,22 @@ test_warn_no_route_override {
     input := {
         "applications": [
             {
+                "name": "foo",
+                "domains": [ "domain.tld", "another.tld" ],
+            },
+            {
+                "name": "bar",
+                "no-route": true
+            }
+        ]
+    }    
+    not warn["Specifying no-route will override all other routing attributes"] with input as input 
+}
+
+test_warn_no_route_override {
+    input := {
+        "applications": [
+            {
                 "name": "application",
                 "host": "app",
                 "no-route": true
@@ -139,6 +165,22 @@ test_warn_no_route_override {
         ]
     }    
     warn["Specifying no-route will override all other routing attributes"] with input as input 
+}
+
+test_warn_no_route_override {
+    input := {
+        "applications": [
+            {
+                "name": "foo",
+                "host": "app",
+            },
+            {   
+                "name": "bar",
+                "no-route": true
+            }
+        ]
+    }    
+    not warn["Specifying no-route will override all other routing attributes"] with input as input 
 }
 
 test_warn_no_route_override {
@@ -155,6 +197,25 @@ test_warn_no_route_override {
         ]
     }    
     warn["Specifying no-route will override all other routing attributes"] with input as input 
+}
+
+test_warn_no_route_override {
+    input := {
+        "applications": [
+            {
+                "name": "foo",
+                "hosts": [
+                    "app",
+                    "another"
+                ]
+            },
+            {
+                "name": "bar",
+                "no-route": true
+            }
+        ]
+    }    
+    not warn["Specifying no-route will override all other routing attributes"] with input as input 
 }
 
 test_warn_random_route_ignored {
@@ -187,6 +248,22 @@ test_warn_random_route_ignored {
     input := {
         "applications": [
             {
+                "name": "foo",
+                "host": "app"
+            },
+            {
+                "name": "bar",
+                "random-route": true
+            }
+        ]
+    }
+    not warn["Random route will not be generated if routes are specified"] with input as input
+}
+
+test_warn_random_route_ignored {
+    input := {
+        "applications": [
+            {
                 "name": "application",
                 "hosts": [
                     "app",
@@ -197,6 +274,25 @@ test_warn_random_route_ignored {
         ]
     }
     warn["Random route will not be generated if routes are specified"] with input as input
+}
+
+test_warn_random_route_ignored {
+    input := {
+        "applications": [
+            {
+                "name": "foo",
+                "hosts": [
+                    "app",
+                    "another"
+                ]
+            },
+            {
+                "name": "bar",
+                "random-route": true
+            }
+        ]
+    }
+    not warn["Random route will not be generated if routes are specified"] with input as input
 }
 
 test_warn_deprecated_domain {
@@ -283,6 +379,25 @@ test_no_routes_with_deprecated_component_attributes {
     input := {
         "applications": [
             {
+                "name": "foo",
+                "routes": [
+                   { "route": "app.host.tld" }
+                ]
+            },
+            {
+                "name": "bar",
+                "domain": "host.tld"
+            }
+        ]
+    }
+    no_violations with input as input
+    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
+}
+
+test_no_routes_with_deprecated_component_attributes {
+    input := {
+        "applications": [
+            {
                 "name": "application",
                 "routes": [
                    { "route": "app.host.tld" }
@@ -296,7 +411,28 @@ test_no_routes_with_deprecated_component_attributes {
     deny["Routes array cannot be used with deprecated routing attributes"] with input as input
 }
 
-test_no_routes_with_deprecated_component_attributes_this_one {
+test_no_routes_with_deprecated_component_attributes {
+    input := {
+        "applications": [
+            {
+                "name": "foo",
+                "routes": [
+                   { "route": "app.host.tld" }
+                ]
+            },
+            {
+                "name": "bar",
+                "domains": [
+                    "host.tld"
+                ]
+            }
+        ]
+    }
+    no_violations with input as input
+    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
+}
+
+test_no_routes_with_deprecated_component_attributes {
     input := {
         "applications": [
             {
@@ -312,6 +448,26 @@ test_no_routes_with_deprecated_component_attributes_this_one {
 }
 
 test_no_routes_with_deprecated_component_attributes {
+    input := { 
+        "applications": [
+            {
+                "name": "foo",
+                "routes": [
+                   { "route": "app.host.tld" }
+                ]
+            },
+            {
+                "name": "bar",
+                "host": "app"
+            }
+        ]
+    } 
+    
+    no_violations with input as input
+    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
+}
+
+test_no_routes_with_deprecated_component_attributes {
     input := {
         "applications": [
             {
@@ -320,10 +476,34 @@ test_no_routes_with_deprecated_component_attributes {
                    { "route": "app.host.tld" }
                 ],
                 "hosts": [
-                    "app.host.tld" 
+                    "app",
+                    "another"
                 ],
             }
         ]
     }
     deny["Routes array cannot be used with deprecated routing attributes"] with input as input
+}
+
+test_no_routes_with_deprecated_component_attributes {
+    input := { 
+        "applications": [
+            {
+                "name": "foo",
+                "routes": [
+                   { "route": "app.host.tld" }
+                ]
+            },
+            {
+                "name": "bar",
+                "hosts": [
+                    "app",
+                    "another"
+                ]
+            }
+        ]
+    } 
+    
+    no_violations with input as input
+    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
 }

--- a/policy/routes_test.rego
+++ b/policy/routes_test.rego
@@ -5,9 +5,6 @@ test_uses_routes_array {
         "applications": [
             {
                 "name": "application",
-                "buildpacks": [
-                    "buildpack"
-                ],
                 "routes": [
                    { "route": "app.host.tld" },
                    { "route": "app.host.tld:1234" },
@@ -18,6 +15,28 @@ test_uses_routes_array {
     } 
     no_violations with input as input
     no_warnings with input as input
+}
+
+test_multiple_apps_routes_and_host {
+    input := { 
+        "applications": [
+            {
+                "name": "foo",
+                "routes": [
+                   { "route": "app.host.tld" },
+                   { "route": "app.host.tld:1234" },
+                   { "route": "app.host.tld/path"}
+                ]
+            },
+            {
+                "name": "bar",
+                "host": "app"
+            }
+        ]
+    } 
+    
+    no_violations with input as input
+    warn["The component attributes for specifying routes have been deprecated. Use the routes array instead."] with input as input
 }
 
 test_route_structure {
@@ -277,7 +296,7 @@ test_no_routes_with_deprecated_component_attributes {
     deny["Routes array cannot be used with deprecated routing attributes"] with input as input
 }
 
-test_no_routes_with_deprecated_component_attributes {
+test_no_routes_with_deprecated_component_attributes_this_one {
     input := {
         "applications": [
             {
@@ -285,7 +304,7 @@ test_no_routes_with_deprecated_component_attributes {
                 "routes": [
                    { "route": "app.host.tld" }
                 ],
-                "host": "app.host.tld" 
+                "host": "app" 
             }
         ]
     }


### PR DESCRIPTION
TL;DR
------

Updates policies (and tests) to avoid false negatives with multiple applications

Details
-------

* Adds a policy that validates that all applications have uniques names
* Refactors policies for routes so that conflicts are checked for the same app
   rather than across the entire array. This avoid false negatives when both 
   supported and deprecated routing attributes are used.
* Updates tests for buildpacks to avoid false negatives when multiple apps use 
   a mix of the supported `buildpacks` array and the single `buildpack` field, or
   when some use multiple buildpacks and others use deprecated routing 
   features.