### PR TITLE
Updates workflow to include a version tag

### DIFF
--- a/.github/actions/conftest-push/action.yml
+++ b/.github/actions/conftest-push/action.yml
@@ -17,6 +17,9 @@ inputs:
   password:
     description: 'Password or personal access token used to log against the Docker registry'
     required: true
+  latest:
+    description: 'Tag for the bundle'
+    default: latest
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,21 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v2
-      - name: Push to Registry
+      - name: Push Registry to Registry Version Tag
         id: push
         uses: ./.github/actions/conftest-push
         with:
           repository: ghcr.io/crdant/cf-manifest-policy
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_TOKEN }}
+          tag: ${{ github.reg }}
+
+      - name: Push to Registry Latest Tag
+        id: push
+        uses: ./.github/actions/conftest-push
+        with:
+          repository: ghcr.io/crdant/cf-manifest-policy
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+          tag: latest
 


### PR DESCRIPTION
TL;DR
-----

Allows older versions to be pulled by pushing with a version tag

Details
-------

Updates the Conftest push action to specify the tag variable, then
uses the updated action to tag the bundle with the version tag.
Also continues to push it with the `latest` tag so that the most
recent version is available by pulling `latest`.