### PR TITLE
Explicitly sets release note in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
+          body: ${{ github.event.head_commit.message }}
           draft: false
           prerelease: true
       - name: Add Bundle as Release Asset


### PR DESCRIPTION
TL;DR
-----

Sets the release note to the commit message on the head

Details
-------

Explicitly sets the release note when cutting the release. Uses
the commit message from the head commit, which it will show with
the release if there isn't a release note. Setting it explicitly
improves the formatting when looking at the list of releases.
